### PR TITLE
test: assert task cleanup

### DIFF
--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -100,6 +100,11 @@ class TestTaskManager(unittest.IsolatedAsyncioTestCase):
         # ✅ Post-conditions
         self.assertTrue(task1.cancelled())
         self.assertTrue(task2.cancelled())
+        # 🧹 Task registry should be empty for all owners
+        self.assertEqual(tm.get_tasks_by_owner("owner1"), set())
+        self.assertEqual(tm.get_tasks_by_owner("owner2"), set())
+        # 🕵️ Unknown owners should also report no tasks
+        self.assertEqual(tm.get_tasks_by_owner("unknown_owner"), set())
 
     async def test_cancel_by_owner(self) -> None:
         """Cancel only the tasks associated with a single owner.


### PR DESCRIPTION
## Summary
- ensure TaskManager returns no tasks for any owner after cancel_all

## Testing
- `python -m pytest tests/test_task_manager.py::TestTaskManager::test_add_and_cancel_all -q`
- `pre-commit run --files tests/test_task_manager.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*

------
https://chatgpt.com/codex/tasks/task_e_68a035822b048321b0fa3c421abae95e