### PR TITLE
chore: use American spelling in TaskManager tests

### DIFF
--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------------------------
 # This module contains asynchronous unit tests for the 🚀 `TaskManager` helper
 # defined in `src.xstate_statemachine.task_manager`.  The `TaskManager`
-# centralises the creation, tracking, and cancellation of `asyncio.Task`
+# centralizes the creation, tracking, and cancellation of `asyncio.Task`
 # objects, grouping them by an **owner ID** so that callers can:
 #
 #   • 🔖 Add tasks under a specific owner.
@@ -15,7 +15,7 @@
 # These tests verify:
 #
 #   1. Correct tracking and clean-up of tasks.
-#   2. Robust behaviour when cancelling *all* tasks or tasks for a
+#   2. Robust behavior when canceling *all* tasks or tasks for a
 #      non-existent owner.
 #   3. Automatic removal of finished tasks via the internal
 #      `done_callback`.


### PR DESCRIPTION
## Summary
- fix TaskManager intro comment to use "centralizes"
- switch remaining British spellings to American for consistency

## Testing
- `pytest tests/test_task_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0346918cc83219845db0445ce9ba4