### PR TITLE
Clarify unsupported async features in SyncInterpreter

### DIFF
--- a/src/xstate_statemachine/sync_interpreter.py
+++ b/src/xstate_statemachine/sync_interpreter.py
@@ -13,6 +13,8 @@
 # It adheres to the "Template Method" pattern by overriding the abstract async
 # methods from `BaseInterpreter` with concrete synchronous implementations,
 # while intentionally raising `NotSupportedError` for features that are
+# incompatible with a purely synchronous runtime (e.g., async services,
+# async actions, or timers requiring an event loop).
 
 # -----------------------------------------------------------------------------
 # 📦 Standard Library Imports


### PR DESCRIPTION
## Summary
- expand SyncInterpreter module comment to clearly state unsupported features like async actions, services, or event-loop timers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a03581c384832189673792b3862338