### PR TITLE
feat: improve inspector diagram styling

### DIFF
--- a/src/xstate_statemachine/inspector/frontend/src/components/StatechartDiagram.tsx
+++ b/src/xstate_statemachine/inspector/frontend/src/components/StatechartDiagram.tsx
@@ -18,7 +18,12 @@ import "reactflow/dist/style.css";
 
 import { MachineState } from "@/hooks/useInspectorSocket";
 import { getLayoutedElements } from "./statechart/layout";
-import { CompoundStateNode, InitialNode, RootNode, StateNode } from "./statechart/nodes";
+import {
+  CompoundStateNode,
+  InitialNode,
+  RootNode,
+  StateNode,
+} from "./statechart/nodes";
 import { TransitionEdge } from "./statechart/edges";
 
 const nodeTypes = {
@@ -36,9 +41,9 @@ interface DiagramProps {
 
 const DiagramCanvas = ({ machine, activeStateIds }: DiagramProps) => {
   const initialLayout = useMemo(
-    () => getLayoutedElements(machine.definition),
-    // Re-layout only when the definition actually changes (e.g., different machine)
-    [machine.definition],
+    () => getLayoutedElements(machine.definition, machine.context),
+    // Re-layout when the definition or context structure changes
+    [machine.definition, machine.context],
   );
 
   // 👉 Controlled state
@@ -70,16 +75,20 @@ const DiagramCanvas = ({ machine, activeStateIds }: DiagramProps) => {
 
   // Keep selection highlighting in sync
   useEffect(() => {
-    setNodes((prev) => prev.map((n) => ({ ...n, selected: activeStateIds.includes(n.id) })));
+    setNodes((prev) =>
+      prev.map((n) => ({ ...n, selected: activeStateIds.includes(n.id) })),
+    );
   }, [activeStateIds]);
 
   // Controlled handlers
   const onNodesChange = useCallback(
-    (changes: NodeChange[]) => setNodes((nds) => applyNodeChanges(changes, nds)),
+    (changes: NodeChange[]) =>
+      setNodes((nds) => applyNodeChanges(changes, nds)),
     [],
   );
   const onEdgesChange = useCallback(
-    (changes: EdgeChange[]) => setEdges((eds) => applyEdgeChanges(changes, eds)),
+    (changes: EdgeChange[]) =>
+      setEdges((eds) => applyEdgeChanges(changes, eds)),
     [],
   );
 
@@ -112,7 +121,9 @@ const DiagramCanvas = ({ machine, activeStateIds }: DiagramProps) => {
     >
       <Controls />
       <MiniMap
-        nodeColor={(n) => (n.selected ? "hsl(var(--primary))" : "hsl(var(--border))")}
+        nodeColor={(n) =>
+          n.selected ? "hsl(var(--primary))" : "hsl(var(--border))"
+        }
         nodeStrokeWidth={3}
       />
       <Background />

--- a/src/xstate_statemachine/inspector/frontend/src/components/statechart/nodes.tsx
+++ b/src/xstate_statemachine/inspector/frontend/src/components/statechart/nodes.tsx
@@ -44,20 +44,33 @@ export const StateNode = ({ data, selected }: NodeProps) => {
     <Card
       className={cn(
         "w-[240px] rounded-lg border shadow-sm bg-card/90",
-        selected ? "ring-2 ring-primary ring-offset-2 ring-offset-background" : "border-border",
+        selected
+          ? "ring-2 ring-primary ring-offset-2 ring-offset-background"
+          : "border-border",
       )}
     >
       {/* Top anchor like XState */}
-      <Handle type="target" position={Position.Top} className="!bg-primary" />
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-transparent opacity-0"
+      />
 
       {/* Only the header acts as drag handle — like XState */}
       <CardHeader className="p-2.5 drag-handle cursor-move bg-muted/60 rounded-t-lg border-b">
-        <CardTitle className="text-[13px] font-semibold tracking-wide">{data.label}</CardTitle>
+        <CardTitle className="text-[13px] font-semibold tracking-wide">
+          {data.label}
+        </CardTitle>
       </CardHeader>
 
       {hasDetails && (
         <CardContent className="p-3">
-          <Section title="Entry" items={entryActions} icon={Zap} colorClass="text-yellow-500" />
+          <Section
+            title="Entry"
+            items={entryActions}
+            icon={Zap}
+            colorClass="text-yellow-500"
+          />
           <Section
             title="Invoke"
             items={invokeServices}
@@ -68,9 +81,21 @@ export const StateNode = ({ data, selected }: NodeProps) => {
       )}
 
       {/* Multiple connection points like XState */}
-      <Handle type="source" position={Position.Bottom} className="!bg-primary" />
-      <Handle type="source" position={Position.Left} className="!bg-primary" />
-      <Handle type="source" position={Position.Right} className="!bg-primary" />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-transparent opacity-0"
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        className="!bg-transparent opacity-0"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!bg-transparent opacity-0"
+      />
     </Card>
   );
 };
@@ -91,13 +116,33 @@ export const CompoundStateNode = (props: NodeProps) => (
 );
 
 // Root state summary
-export const RootNode = (props: NodeProps) => (
-  <Card className="bg-card/80">
-    <CardHeader className="p-3">
-      <CardTitle className="text-sm">{props.data.label}</CardTitle>
-      {/* Add any context preview if desired */}
-    </CardHeader>
-  </Card>
-);
+export const RootNode = ({ data }: NodeProps) => {
+  const ctxEntries = Object.entries(data.context ?? {}).map(([k, v]) => ({
+    key: k,
+    type: typeof v,
+  }));
 
-export const InitialNode = () => <div className="w-6 h-6 rounded-full bg-foreground" />;
+  return (
+    <Card className="bg-card/80">
+      <CardHeader className="p-3 border-b">
+        <CardTitle className="text-sm">{data.label}</CardTitle>
+      </CardHeader>
+      {ctxEntries.length > 0 && (
+        <CardContent className="p-3">
+          <h4 className="text-[10px] font-semibold text-muted-foreground mb-1 tracking-wide uppercase">
+            Context
+          </h4>
+          {ctxEntries.map(({ key, type }) => (
+            <div key={key} className="text-[12px] leading-5">
+              <span className="font-mono font-medium">{key}</span>: {type}
+            </div>
+          ))}
+        </CardContent>
+      )}
+    </Card>
+  );
+};
+
+export const InitialNode = () => (
+  <div className="w-0 h-0 border-t-4 border-b-4 border-l-8 border-t-transparent border-b-transparent border-l-foreground" />
+);


### PR DESCRIPTION
## Summary
- hide connection handles and add initial-state arrow
- show machine context and wrap states in root container
- pass context to layout and resize root node to fit children

## Testing
- `pre-commit run --files src/xstate_statemachine/inspector/frontend/src/components/StatechartDiagram.tsx src/xstate_statemachine/inspector/frontend/src/components/statechart/layout.ts src/xstate_statemachine/inspector/frontend/src/components/statechart/nodes.tsx` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `npm run build` *(fails: Cannot find module '@/lib/utils' or its corresponding type declarations)*


------
https://chatgpt.com/codex/tasks/task_e_68a04c3edf7c832185bfd33fa5039786