### PR TITLE
fix: stabilize wrapper during node drag

### DIFF
--- a/src/xstate_statemachine/inspector/frontend/src/components/statechart/diagram/useDiagram.ts
+++ b/src/xstate_statemachine/inspector/frontend/src/components/statechart/diagram/useDiagram.ts
@@ -211,16 +211,11 @@ export const useDiagram = ({
         const dragging = changes.some((c) => c.type === "position" && c.dragging);
 
         if (dragging) {
-          // During drag, avoid horizontal wrapper shifts from transient edge changes.
-          let guardedNodes: Node[] = [];
-          setEdges((eds) => {
-            guardedNodes = guardHeaderAndMaybeGrow(next, eds, draggingIds);
-            return withHeaderClamp(
-              recomputeEdgeHandles(eds, guardedNodes, draggingIds),
-              guardedNodes,
-            );
-          });
-          return decorateStatuses(guardedNodes, edges);
+          // While dragging, keep the wrapper stable to avoid flickering
+          // and temporary disappearance of nodes. Only recompute edge
+          // handles; defer wrapper adjustments until drag end.
+          setEdges((eds) => withHeaderClamp(recomputeEdgeHandles(eds, next, draggingIds), next));
+          return decorateStatuses(next, edges);
         }
 
         if (isDrop) {


### PR DESCRIPTION
## Summary
- prevent wrapper adjustments while dragging nodes to avoid flicker

## Testing
- `pre-commit run --files src/xstate_statemachine/inspector/frontend/src/components/statechart/diagram/useDiagram.ts`
- `pytest` *(fails: KeyError: 'context_diff'; AssertionError: Expected '_handle_inspection_event' to have been called once. Called 2 times.)*


------
https://chatgpt.com/codex/tasks/task_e_68b7de9e8c388321a310fa8125910e52